### PR TITLE
[REFACTOR] Provider Layer 에 관심사 분리

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/provider/BuyNowProvider.java
+++ b/src/main/java/bc1/gream/domain/buy/provider/BuyNowProvider.java
@@ -3,6 +3,7 @@ package bc1.gream.domain.buy.provider;
 import bc1.gream.domain.buy.dto.request.BuyNowRequestDto;
 import bc1.gream.domain.buy.dto.response.BuyNowResponseDto;
 import bc1.gream.domain.buy.service.query.BuyQueryService;
+import bc1.gream.domain.buy.validator.BuyAvailabilityVerifier;
 import bc1.gream.domain.coupon.entity.Coupon;
 import bc1.gream.domain.coupon.service.command.CouponCommandService;
 import bc1.gream.domain.coupon.service.qeury.CouponQueryService;
@@ -34,6 +35,8 @@ public class BuyNowProvider {
         Sell sell = sellQueryService.getRecentSellBidof(productId, requestDto.price());
         // 쿠폰 조회
         Coupon coupon = couponQueryService.getCouponFrom(requestDto.couponId(), buyer);
+        // 구매자에 대한 구매가능성 여부 검증
+        BuyAvailabilityVerifier.verifyBuyerEligibility(sell.getPrice(), coupon, buyer);
 
         // 새로운 주문
         Order order = orderCommandService.saveOrderOf(sell, buyer, coupon);
@@ -41,10 +44,6 @@ public class BuyNowProvider {
         sell.getGifticon().updateOrder(order);
         // 해당 판매입찰 삭제
         sellCommandService.delete(sell);
-
-        // 구매가능검증 :: 사용자 포인트가 finalPrice 보다 작다면 예외처리
-        // << 이건 컨트롤러 단에서 검증 해줘야하 하지 않을까???
-        buyQueryService.userPointCheck(buyer, order.getFinalPrice());
 
         // 즉시구매자 포인트 감소
         buyer.decreasePoint(order.getFinalPrice());

--- a/src/main/java/bc1/gream/domain/buy/provider/BuyNowProvider.java
+++ b/src/main/java/bc1/gream/domain/buy/provider/BuyNowProvider.java
@@ -4,7 +4,6 @@ import bc1.gream.domain.buy.dto.request.BuyNowRequestDto;
 import bc1.gream.domain.buy.dto.response.BuyNowResponseDto;
 import bc1.gream.domain.buy.service.query.BuyQueryService;
 import bc1.gream.domain.coupon.entity.Coupon;
-import bc1.gream.domain.coupon.entity.CouponStatus;
 import bc1.gream.domain.coupon.service.command.CouponCommandService;
 import bc1.gream.domain.coupon.service.qeury.CouponQueryService;
 import bc1.gream.domain.order.entity.Order;
@@ -34,10 +33,10 @@ public class BuyNowProvider {
         // 해당상품과 가격에 대한 판매입찰
         Sell sell = sellQueryService.getRecentSellBidof(productId, requestDto.price());
         // 쿠폰 조회
-        Coupon coupon = getCoupon(requestDto.couponId(), buyer);
+        Coupon coupon = couponQueryService.getCouponFrom(requestDto.couponId(), buyer);
 
         // 새로운 주문
-        Order order = saveOrder(sell, buyer, coupon);
+        Order order = orderCommandService.saveOrderOf(sell, buyer, coupon);
         // 판매입찰 기프티콘에 주문 저장
         sell.getGifticon().updateOrder(order);
         // 해당 판매입찰 삭제
@@ -54,21 +53,5 @@ public class BuyNowProvider {
 
         // 매핑
         return OrderMapper.INSTANCE.toBuyNowResponseDto(order);
-    }
-
-    private Coupon getCoupon(Long couponId, User buyer) {
-        if (couponId != null) {
-            Coupon coupon = couponQueryService.checkCoupon(couponId, buyer, CouponStatus.AVAILABLE);
-            couponCommandService.changeCouponStatus(coupon, CouponStatus.ALREADY_USED);
-            return coupon;
-        }
-        return null;
-    }
-
-    private Order saveOrder(Sell sell, User buyer, Coupon coupon) {
-        if (coupon != null) {
-            return orderCommandService.saveOrderOfSell(sell, buyer, coupon);
-        }
-        return orderCommandService.saveOrderOfSellNotCoupon(sell, buyer);
     }
 }

--- a/src/main/java/bc1/gream/domain/buy/service/query/BuyQueryService.java
+++ b/src/main/java/bc1/gream/domain/buy/service/query/BuyQueryService.java
@@ -1,7 +1,6 @@
 package bc1.gream.domain.buy.service.query;
 
 import static bc1.gream.global.common.ResultCase.BUY_BID_NOT_FOUND;
-import static bc1.gream.global.common.ResultCase.NOT_ENOUGH_POINT;
 
 import bc1.gream.domain.buy.dto.response.BuyCheckBidResponseDto;
 import bc1.gream.domain.buy.entity.Buy;
@@ -13,9 +12,9 @@ import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
-import java.time.LocalDateTime;
 import bc1.gream.global.redis.RedisCacheName;
 import bc1.gream.global.redis.RestPage;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheConfig;
@@ -83,11 +82,5 @@ public class BuyQueryService {
         }
 
         return CouponCalculator.calculateDiscount(coupon, discountPrice);
-    }
-
-    public void userPointCheck(User user, Long finalPrice) {
-        if (user.getPoint() < finalPrice) {
-            throw new GlobalException(NOT_ENOUGH_POINT);
-        }
     }
 }

--- a/src/main/java/bc1/gream/domain/buy/validator/BuyAvailabilityVerifier.java
+++ b/src/main/java/bc1/gream/domain/buy/validator/BuyAvailabilityVerifier.java
@@ -1,0 +1,27 @@
+package bc1.gream.domain.buy.validator;
+
+import static bc1.gream.global.common.ResultCase.NOT_ENOUGH_POINT;
+
+import bc1.gream.domain.coupon.entity.Coupon;
+import bc1.gream.domain.coupon.helper.CouponCalculator;
+import bc1.gream.domain.user.entity.User;
+import bc1.gream.global.exception.GlobalException;
+
+public class BuyAvailabilityVerifier {
+
+    /**
+     * 입찰가와 쿠폰에 따른 최종가격에 대해 구매자의 구매가능성 여부 검증
+     *
+     * @param price  입찰가
+     * @param coupon 쿠폰
+     * @param buyer  구매자
+     * @throws GlobalException when 구매자 포인트 < 할인적용된 최종가
+     */
+    public static void verifyBuyerEligibility(Long price, Coupon coupon, User buyer) {
+        Long finalPrice = CouponCalculator.calculateDiscount(coupon, price);
+
+        if (buyer.getPoint() < finalPrice) {
+            throw new GlobalException(NOT_ENOUGH_POINT);
+        }
+    }
+}

--- a/src/main/java/bc1/gream/domain/coupon/helper/CouponCalculator.java
+++ b/src/main/java/bc1/gream/domain/coupon/helper/CouponCalculator.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.coupon.helper;
 
-import bc1.gream.domain.coupon.entity.DiscountType;
 import bc1.gream.domain.coupon.entity.Coupon;
+import bc1.gream.domain.coupon.entity.DiscountType;
 
 public final class CouponCalculator {
 
@@ -13,7 +13,10 @@ public final class CouponCalculator {
      * @return 할인된 가격
      */
     public static Long calculateDiscount(Coupon coupon, Long price) {
-        DiscountType discountType = coupon.getDiscountType();
-        return discountType.calculateDiscount(coupon, price);
+        if (coupon != null) {
+            DiscountType discountType = coupon.getDiscountType();
+            return discountType.calculateDiscount(coupon, price);
+        }
+        return price;
     }
 }

--- a/src/main/java/bc1/gream/domain/coupon/service/qeury/CouponQueryService.java
+++ b/src/main/java/bc1/gream/domain/coupon/service/qeury/CouponQueryService.java
@@ -3,6 +3,7 @@ package bc1.gream.domain.coupon.service.qeury;
 import static bc1.gream.global.common.ResultCase.COUPON_NOT_FOUND;
 import static bc1.gream.global.common.ResultCase.NOT_AUTHORIZED;
 
+import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.coupon.entity.Coupon;
 import bc1.gream.domain.coupon.entity.CouponStatus;
 import bc1.gream.domain.coupon.repository.CouponRepository;
@@ -11,6 +12,7 @@ import bc1.gream.global.common.ResultCase;
 import bc1.gream.global.exception.GlobalException;
 import bc1.gream.global.security.UserDetailsImpl;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,5 +63,22 @@ public class CouponQueryService {
 
     public boolean isMatchCouponUser(User user, Coupon coupon) {
         return coupon.getUser().getLoginId().equals(user.getLoginId());
+    }
+
+
+    /**
+     * 구매입찰로부터 쿠폰 조회
+     *
+     * @param buy 구매입찰
+     * @return 구매입찰 시 등록된 쿠폰, 없다면 null 반환
+     */
+    public Coupon getCouponFrom(Buy buy) {
+        if (Objects.isNull(buy.getCouponId())) {
+            return null;
+        }
+        // 쿠폰 조회, 사용처리
+        Coupon coupon = findCouponById(buy.getCouponId(), buy.getUser());
+        coupon.changeStatus(CouponStatus.ALREADY_USED);
+        return coupon;
     }
 }

--- a/src/main/java/bc1/gream/domain/coupon/service/qeury/CouponQueryService.java
+++ b/src/main/java/bc1/gream/domain/coupon/service/qeury/CouponQueryService.java
@@ -63,6 +63,13 @@ public class CouponQueryService {
         return coupon.getUser().getLoginId().equals(user.getLoginId());
     }
 
+    /**
+     * 쿠폰아이디와 쿠폰주인에 따라 쿠폰조회 이후 쿠폰상태 변경
+     *
+     * @param couponId 쿠폰아이디
+     * @param user     쿠폰주인
+     * @return 쿠폰
+     */
     public Coupon getCouponFrom(Long couponId, User user) {
         if (couponId != null) {
             Coupon coupon = checkCoupon(couponId, user, CouponStatus.AVAILABLE);

--- a/src/main/java/bc1/gream/domain/coupon/service/qeury/CouponQueryService.java
+++ b/src/main/java/bc1/gream/domain/coupon/service/qeury/CouponQueryService.java
@@ -3,7 +3,6 @@ package bc1.gream.domain.coupon.service.qeury;
 import static bc1.gream.global.common.ResultCase.COUPON_NOT_FOUND;
 import static bc1.gream.global.common.ResultCase.NOT_AUTHORIZED;
 
-import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.coupon.entity.Coupon;
 import bc1.gream.domain.coupon.entity.CouponStatus;
 import bc1.gream.domain.coupon.repository.CouponRepository;
@@ -12,7 +11,6 @@ import bc1.gream.global.common.ResultCase;
 import bc1.gream.global.exception.GlobalException;
 import bc1.gream.global.security.UserDetailsImpl;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,20 +63,12 @@ public class CouponQueryService {
         return coupon.getUser().getLoginId().equals(user.getLoginId());
     }
 
-
-    /**
-     * 구매입찰로부터 쿠폰 조회
-     *
-     * @param buy 구매입찰
-     * @return 구매입찰 시 등록된 쿠폰, 없다면 null 반환
-     */
-    public Coupon getCouponFrom(Buy buy) {
-        if (Objects.isNull(buy.getCouponId())) {
-            return null;
+    public Coupon getCouponFrom(Long couponId, User user) {
+        if (couponId != null) {
+            Coupon coupon = checkCoupon(couponId, user, CouponStatus.AVAILABLE);
+            coupon.changeStatus(CouponStatus.ALREADY_USED);
+            return coupon;
         }
-        // 쿠폰 조회, 사용처리
-        Coupon coupon = findCouponById(buy.getCouponId(), buy.getUser());
-        coupon.changeStatus(CouponStatus.ALREADY_USED);
-        return coupon;
+        return null;
     }
 }

--- a/src/main/java/bc1/gream/domain/order/service/command/OrderCommandService.java
+++ b/src/main/java/bc1/gream/domain/order/service/command/OrderCommandService.java
@@ -90,10 +90,25 @@ public class OrderCommandService {
      * @param coupon 쿠폰
      * @return 체결된 주문
      */
-    public Order saveOrder(Buy buy, User seller, Coupon coupon) {
+    public Order saveOrderOf(Buy buy, User seller, Coupon coupon) {
         if (coupon != null) {
             return saveOrderOfBuy(buy, seller, coupon);
         }
         return saveOrderOfBuyNotCoupon(buy, seller);
+    }
+
+    /**
+     * 즉시구매 시, 쿠폰 상태에 따른 주문 체결
+     *
+     * @param sell   구매입찰
+     * @param buyer  구매자
+     * @param coupon 쿠폰
+     * @return 체결된 주문
+     */
+    public Order saveOrderOf(Sell sell, User buyer, Coupon coupon) {
+        if (coupon != null) {
+            return saveOrderOfSell(sell, buyer, coupon);
+        }
+        return saveOrderOfSellNotCoupon(sell, buyer);
     }
 }

--- a/src/main/java/bc1/gream/domain/order/service/command/OrderCommandService.java
+++ b/src/main/java/bc1/gream/domain/order/service/command/OrderCommandService.java
@@ -81,4 +81,19 @@ public class OrderCommandService {
 
         return orderRepository.save(order);
     }
+
+    /**
+     * 즉시판매 시, 쿠폰 상태에 따른 주문 체결
+     *
+     * @param buy    판매입찰
+     * @param seller 판매자
+     * @param coupon 쿠폰
+     * @return 체결된 주문
+     */
+    public Order saveOrder(Buy buy, User seller, Coupon coupon) {
+        if (coupon != null) {
+            return saveOrderOfBuy(buy, seller, coupon);
+        }
+        return saveOrderOfBuyNotCoupon(buy, seller);
+    }
 }

--- a/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
@@ -10,13 +10,10 @@ import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.mapper.SellMapper;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.sell.service.command.SellCommandService;
-import bc1.gream.domain.sell.service.helper.deadline.Deadline;
 import bc1.gream.domain.sell.service.helper.deadline.DeadlineCalculator;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.infra.s3.S3ImageService;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,13 +34,10 @@ public class SellBidProvider {
 
         // 기프티콘 이미지 S3 저장
         String url = s3ImageService.getUrlAfterUpload(requestDto.file());
-
         // 기프티콘 생성, 저장
         Gifticon gifticon = gifticonCommandService.saveGifticon(url, null);
-        // 마감기한 지정 : LocalTime.Max :: 23시 59분 59초
-        Integer period = Deadline.getPeriod(requestDto.period());
-        LocalDateTime deadlineAt = DeadlineCalculator.calculateDeadlineBy(LocalDate.now(), LocalTime.MAX,
-            period);
+        // 마감기한 계산
+        LocalDateTime deadlineAt = DeadlineCalculator.getDeadlineOf(requestDto);
 
         // 판매입찰 생성 및 저장
         Sell sell = Sell.builder()
@@ -58,7 +52,6 @@ public class SellBidProvider {
         // 매퍼로 변환
         return SellMapper.INSTANCE.toSellBidResponseDto(savedSell);
     }
-
 
     public SellCancelBidResponseDto sellCancelBid(User seller, Long sellId) {
         Sell deletedSell = sellCommandService.deleteSellByIdAndUser(sellId, seller);

--- a/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
@@ -31,14 +31,13 @@ public class SellBidProvider {
 
     @Transactional
     public SellBidResponseDto createSellBid(User seller, SellBidRequestDto requestDto, Product product) {
-
         // 기프티콘 이미지 S3 저장
         String url = s3ImageService.getUrlAfterUpload(requestDto.file());
         // 기프티콘 생성, 저장
         Gifticon gifticon = gifticonCommandService.saveGifticon(url, null);
-        // 마감기한 계산
-        LocalDateTime deadlineAt = DeadlineCalculator.getDeadlineOf(requestDto);
 
+        // 마감기한 계산
+        LocalDateTime deadlineAt = DeadlineCalculator.getDeadlineOf(requestDto.period());
         // 판매입찰 생성 및 저장
         Sell sell = Sell.builder()
             .price(requestDto.price())
@@ -53,6 +52,7 @@ public class SellBidProvider {
         return SellMapper.INSTANCE.toSellBidResponseDto(savedSell);
     }
 
+    @Transactional
     public SellCancelBidResponseDto sellCancelBid(User seller, Long sellId) {
         Sell deletedSell = sellCommandService.deleteSellByIdAndUser(sellId, seller);
         gifticonCommandService.delete(deletedSell.getGifticon());

--- a/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
@@ -4,7 +4,6 @@ import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.service.command.BuyCommandService;
 import bc1.gream.domain.buy.service.query.BuyQueryService;
 import bc1.gream.domain.coupon.entity.Coupon;
-import bc1.gream.domain.coupon.entity.CouponStatus;
 import bc1.gream.domain.coupon.service.qeury.CouponQueryService;
 import bc1.gream.domain.gifticon.service.command.GifticonCommandService;
 import bc1.gream.domain.order.entity.Order;
@@ -14,7 +13,6 @@ import bc1.gream.domain.sell.dto.request.SellNowRequestDto;
 import bc1.gream.domain.sell.dto.response.SellNowResponseDto;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.infra.s3.S3ImageService;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellNowProvider {
 
     private final BuyQueryService buyQueryService;
-    private final BuyCommandService commandService;
+    private final BuyCommandService buyCommandService;
     private final CouponQueryService couponQueryService;
     private final OrderCommandService orderCommandService;
     private final GifticonCommandService gifticonCommandService;
@@ -36,45 +34,23 @@ public class SellNowProvider {
         // 해당상품과 가격에 대한 구매입찰
         Buy buy = buyQueryService.getRecentBuyBidOf(productId, requestDto.price());
         // 쿠폰 조회
-        Coupon coupon = getCouponFrom(buy);
+        Coupon coupon = couponQueryService.getCouponFrom(buy);
         // 새로운 주문
-        Order order = saveOrder(buy, user, coupon);
+        Order order = orderCommandService.saveOrder(buy, user, coupon);
 
         // 기프티콘 이미지 S3 저장
         String url = s3ImageService.getUrlAfterUpload(requestDto.file());
 
         // 새로운 기프티콘 저장
         gifticonCommandService.saveGifticon(url, order);
+
         // 판매에 따른 사용자 포인트 충전
         user.increasePoint(order.getExpectedPrice());
 
         // 구매입찰 삭제
-        commandService.delete(buy);
+        buyCommandService.delete(buy);
 
         // 매퍼를 통해 변환
         return OrderMapper.INSTANCE.toSellNowResponseDto(order);
-    }
-
-    /**
-     * 구매입찰로부터 쿠폰 조회
-     *
-     * @param buy 구매입찰
-     * @return 구매입찰 시 등록된 쿠폰, 없다면 null 반환
-     */
-    private Coupon getCouponFrom(Buy buy) {
-        if (Objects.isNull(buy.getCouponId())) {
-            return null;
-        }
-        // 쿠폰 조회, 사용처리
-        Coupon coupon = couponQueryService.findCouponById(buy.getCouponId(), buy.getUser());
-        coupon.changeStatus(CouponStatus.ALREADY_USED);
-        return coupon;
-    }
-
-    private Order saveOrder(Buy buy, User seller, Coupon coupon) {
-        if (coupon != null) {
-            return orderCommandService.saveOrderOfBuy(buy, seller, coupon);
-        }
-        return orderCommandService.saveOrderOfBuyNotCoupon(buy, seller);
     }
 }

--- a/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
@@ -34,9 +34,9 @@ public class SellNowProvider {
         // 해당상품과 가격에 대한 구매입찰
         Buy buy = buyQueryService.getRecentBuyBidOf(productId, requestDto.price());
         // 쿠폰 조회
-        Coupon coupon = couponQueryService.getCouponFrom(buy);
+        Coupon coupon = couponQueryService.getCouponFrom(buy.getCouponId(), buy.getUser());
         // 새로운 주문
-        Order order = orderCommandService.saveOrder(buy, user, coupon);
+        Order order = orderCommandService.saveOrderOf(buy, user, coupon);
 
         // 기프티콘 이미지 S3 저장
         String url = s3ImageService.getUrlAfterUpload(requestDto.file());

--- a/src/main/java/bc1/gream/domain/sell/service/helper/deadline/DeadlineCalculator.java
+++ b/src/main/java/bc1/gream/domain/sell/service/helper/deadline/DeadlineCalculator.java
@@ -1,17 +1,20 @@
 package bc1.gream.domain.sell.service.helper.deadline;
 
-import bc1.gream.domain.sell.dto.request.SellBidRequestDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public final class DeadlineCalculator {
 
-    public static LocalDateTime getDeadlineOf(SellBidRequestDto requestDto) {
-        Integer period = Deadline.getPeriod(requestDto.period());
-        LocalDateTime deadlineAt = DeadlineCalculator.calculateDeadlineBy(LocalDate.now(), LocalTime.MAX,
-            period);
-        return deadlineAt;
+    /**
+     * 현재일자로부터 입력주기에 따른 마감일자를 반환
+     *
+     * @param period 입력주기
+     * @return 마감일자
+     */
+    public static LocalDateTime getDeadlineOf(Integer period) {
+        Integer calculatedPeriod = Deadline.getPeriod(period);
+        return calculateDeadlineBy(LocalDate.now(), LocalTime.MAX, calculatedPeriod);
     }
 
     /**

--- a/src/main/java/bc1/gream/domain/sell/service/helper/deadline/DeadlineCalculator.java
+++ b/src/main/java/bc1/gream/domain/sell/service/helper/deadline/DeadlineCalculator.java
@@ -1,10 +1,18 @@
 package bc1.gream.domain.sell.service.helper.deadline;
 
+import bc1.gream.domain.sell.dto.request.SellBidRequestDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public final class DeadlineCalculator {
+
+    public static LocalDateTime getDeadlineOf(SellBidRequestDto requestDto) {
+        Integer period = Deadline.getPeriod(requestDto.period());
+        LocalDateTime deadlineAt = DeadlineCalculator.calculateDeadlineBy(LocalDate.now(), LocalTime.MAX,
+            period);
+        return deadlineAt;
+    }
 
     /**
      * 해당 날짜 date 의 시간대 time 로부터 마감일 period 후의 날짜 반환

--- a/src/test/java/bc1/gream/domain/buy/service/query/BuyQueryServiceTest.java
+++ b/src/test/java/bc1/gream/domain/buy/service/query/BuyQueryServiceTest.java
@@ -29,7 +29,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class BuyQueryServiceTest implements BuyTest, CouponTest {
@@ -61,9 +60,7 @@ class BuyQueryServiceTest implements BuyTest, CouponTest {
         given(buyRepository.findById(any(Long.class))).willReturn(Optional.empty());
 
         // when
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            buyQueryService.findBuyById(any(Long.class));
-        });
+        GlobalException exception = assertThrows(GlobalException.class, () -> buyQueryService.findBuyById(any(Long.class)));
 
         // then
         assertThat(exception.getResultCase()).isEqualTo(ResultCase.BUY_BID_NOT_FOUND);
@@ -130,9 +127,8 @@ class BuyQueryServiceTest implements BuyTest, CouponTest {
             Optional.empty());
 
         // when
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            buyQueryService.getRecentBuyBidOf(TEST_PRODUCT_ID, TEST_BUY_PRICE);
-        });
+        GlobalException exception = assertThrows(GlobalException.class,
+            () -> buyQueryService.getRecentBuyBidOf(TEST_PRODUCT_ID, TEST_BUY_PRICE));
 
         // then
         assertThat(exception.getResultCase()).isEqualTo(ResultCase.BUY_BID_NOT_FOUND);
@@ -155,7 +151,7 @@ class BuyQueryServiceTest implements BuyTest, CouponTest {
 
             responseDtoList.add(responseDto);
         }
-        given(buyRepository.findAllBuyBidCoupon(any(User.class))).willReturn(responseDtoList);
+        given(buyRepository.findAllBuyBidCoupon(any(User.class), any(LocalDateTime.class))).willReturn(responseDtoList);
 
         // when
         List<BuyCheckBidResponseDto> resultList = buyQueryService.findAllBuyBidCoupon(TEST_USER);
@@ -200,32 +196,5 @@ class BuyQueryServiceTest implements BuyTest, CouponTest {
         assertThat(resultList.get(1).discountPrice()).isEqualTo(responseDtoList.get(1).discountPrice());
         assertThat(resultList.get(2).discountPrice()).isEqualTo(responseDtoList.get(2).discountPrice());
         assertThat(resultList.get(3).discountPrice()).isEqualTo(responseDtoList.get(3).discountPrice());
-    }
-
-    @Test
-    void 유저의_포인트_체크하는_서비스_기능_성공_테스트() {
-
-        // given
-        ReflectionTestUtils.setField(TEST_USER, "point", 10000L);
-
-        // when - then
-        buyQueryService.userPointCheck(TEST_USER, 5000L);
-    }
-
-    @Test
-    void 유저의_포인트_체크하는_서비스_기능_실패_테스트() {
-
-        // given
-        ReflectionTestUtils.setField(TEST_USER, "point", 3000L);
-
-        // when
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            buyQueryService.userPointCheck(TEST_USER, 5000L);
-        });
-
-        // then
-        assertThat(exception.getResultCase()).isEqualTo(ResultCase.NOT_ENOUGH_POINT);
-        assertThat(exception.getResultCase().getCode()).isEqualTo(1007);
-        assertThat(exception.getResultCase().getMessage()).isEqualTo("유저의 포인트가 부족합니다");
     }
 }


### PR DESCRIPTION
## 개요
Provider Layer 에 대해서 각자의 역할에 따르게끔 최대한 관심사 분리를 해보았습니다.


## 작업사항
### 각 도메인 별 역할 수행 처리
- 쿠폰 조회 : CouponQueryService
- 구매자 구매가능성 여부 검증 : BuyAvailabilityVerifier
- 할인된 최종가격 : CouponCalculator
- 마감기한 계산 : DeadlineCalculator
- 쿠폰 상태에 따른 주문체결 : OrderCommandService

### Provider Layer 에서 관심사 분리
- SellNowProvider 로부터 관심사 분리  
- SellBidProvider 로부터 관심사 분리 
- BuyNowProvider 로부터 관심사 분리
- BuyBidProvider 로부터 관심사 분리

## 관련 이슈
- close #275 
