### PR TITLE
cd-v2.yml 에서 actions 버전 업데이트

### DIFF
--- a/.github/workflows/cd-v2.yml
+++ b/.github/workflows/cd-v2.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
 
       - name: aws configure
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: build docker file and setting deploy files
         env:


### PR DESCRIPTION
## 개요
> Node 16 이 deprecated 됨에 따라 20에 맞는 actions 버전 업데이트

## 부연설명

[8313357691번 배포](https://github.com/Team-BC-1/gream-backend/actions/runs/8313357691) 에서 아래와 같이 노팅이 나왔습니다.

>
- Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: aws-actions/configure-aws-credentials@v1, aws-actions/amazon-ecr-login@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.Show less
>
- The following actions uses node12 which is deprecated and will be forced to run on node16: aws-actions/configure-aws-credentials@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/Show less
>
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/Show less
>
- Your docker password is not masked. See https://github.com/aws-actions/amazon-ecr-login#docker-credentials for more information.

이에 따라 아래 작업사항을 구현하였습니다.

## 작업사항
- aws-actions/configure-aws-credentials@v1 -> aws-actions/configure-aws-credentials@v4
- aws-actions/amazon-ecr-login@v1 -> aws-actions/amazon-ecr-login@v2

## 관련 이슈
- close #294 







