### PR TITLE
비관적 락 사용한 조회 호출에 대한 재시도 처리 적용

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/service/query/BuyQueryService.java
+++ b/src/main/java/bc1/gream/domain/buy/service/query/BuyQueryService.java
@@ -21,6 +21,8 @@ import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,6 +59,7 @@ public class BuyQueryService {
      * @param price     구매를 원하는 상품 가격
      * @return 구매입찰
      */
+    @Retryable(backoff = @Backoff(delay = 100))
     public Buy getRecentBuyBidOf(Long productId, Long price) {
         return buyRepository.findByProductIdAndPrice(productId, price, LocalDateTime.now())
             .orElseThrow(() -> new GlobalException(BUY_BID_NOT_FOUND));

--- a/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
@@ -8,15 +8,17 @@ import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
-import java.time.LocalDateTime;
 import bc1.gream.global.redis.RedisCacheName;
 import bc1.gream.global.redis.RestPage;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +52,7 @@ public class SellQueryService {
     }
 
     @Transactional(readOnly = true)
+    @Retryable(backoff = @Backoff(delay = 100))
     public Sell getRecentSellBidof(Long productId, Long price) {
         return sellRepository.findByProductIdAndPrice(productId, price, LocalDateTime.now()).orElseThrow(
             () -> new GlobalException(SELL_BID_PRODUCT_NOT_FOUND)


### PR DESCRIPTION
## 개요
> 비관적 락 사용한 조회 호출하는 메서드가 존재합니다. 
여러 스레드가 경합하는 경우, 대기시간에 따라 타임아웃 예외가 발생할 수 있습니다. 
따라서 이에 대한 AOP를 적용하여 최대 3회(기본값) 재시도 처리를 하게끔 구현하였습니다.

## 작업사항
- SellQueryService 에 @retryable 적용 (delay 100ms 설정)
- BuyQueryService 에 @retryable 적용 (delay 100ms 설정)

## 관련 이슈
- close #298 
